### PR TITLE
feat: adding migration system

### DIFF
--- a/migrations/changes/0001-initialize-database.sql
+++ b/migrations/changes/0001-initialize-database.sql
@@ -1,0 +1,4 @@
+CREATE TABLE IF NOT EXISTS 'streamers' (
+	name VARCHAR(255) PRIMARY KEY,
+	last_stream DATE
+);

--- a/migrations/migrate.js
+++ b/migrations/migrate.js
@@ -1,0 +1,78 @@
+import config from "../config.json" with { type: "json" };
+import { DatabaseSync } from "node:sqlite";
+import fs from "fs";
+import path from "path";
+import process from "process";
+
+const database = new DatabaseSync(config.databasePath);
+
+function initializeMigrations() {
+  database.exec(`
+CREATE TABLE IF NOT EXISTS 'migrations' (
+	name VARCHAR(1000) PRIMARY KEY NOT NULL,
+	done_at DATE
+);
+	`);
+}
+function hasMigrationBeenApplied(name) {
+  const query = database.prepare(
+    `SELECT * FROM migrations WHERE migrations.name = (?)`,
+  );
+  const res = query.all(name);
+  if (res.length >= 1) {
+    return true;
+  }
+  return false;
+}
+function insertMigration(name) {
+  const query = database.prepare(
+    `INSERT INTO migrations (name, done_at) VALUES (?, ?)`,
+  );
+  query.run(name, Date.now());
+}
+function applyMigration(content) {
+  const query = database.prepare(content);
+  query.run();
+}
+
+function runMigrations() {
+  const migrationsFolder = "migrations/changes";
+
+  const filesNames = fs
+    .readdirSync(migrationsFolder, { withFileTypes: true })
+    .filter((item) => !item.isDirectory() && path.extname(item.name) === ".sql")
+    .map((file) => file.name);
+
+  let migrationsApplied = 0;
+  for (const fileName of filesNames) {
+    let migrationContent;
+
+    try {
+      migrationContent = fs.readFileSync(
+        path.join(migrationsFolder, fileName),
+        "utf8",
+      );
+    } catch (e) {
+      console.error(
+        `An error occured while reading migration ${fileName} : ${e}`,
+      );
+      process.exit(1);
+    }
+
+    if (!hasMigrationBeenApplied(fileName)) {
+      console.log(`Applying migration ${fileName}`);
+      applyMigration(migrationContent);
+      insertMigration(fileName);
+      migrationsApplied++;
+    }
+  }
+
+  if (migrationsApplied > 0) {
+    console.log("Migration has been applied successfully!");
+  } else {
+    console.log("No migration to apply.");
+  }
+}
+
+initializeMigrations();
+runMigrations();

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "start": "node --experimental-sqlite src/index.js",
     "debug": "nodemon src/index.js",
+		"migrate": "node --experimental-sqlite migrations/migrate.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "author": "",

--- a/src/index.js
+++ b/src/index.js
@@ -1,7 +1,6 @@
 import { Client, GatewayIntentBits } from "discord.js";
 import { handleMessage, startBot } from "./services/bot.js";
 import config from "../config.json" with { type: "json" };
-import { initializeDatabase } from "./services/database.js";
 
 const client = new Client({
   intents: [
@@ -14,7 +13,6 @@ const client = new Client({
 // listener on bot ready
 client.on("ready", () => {
   console.log("Discord bot is connected");
-  initializeDatabase();
   startBot(client);
 });
 

--- a/src/services/database.js
+++ b/src/services/database.js
@@ -2,16 +2,6 @@ import config from "../../config.json" with { type: "json" };
 import { DatabaseSync } from "node:sqlite";
 export const database = new DatabaseSync(config.databasePath);
 
-export function initializeDatabase() {
-  // only creating a 'streamers' table for now
-  // it will only be used by us so...
-  database.exec(`
-CREATE TABLE IF NOT EXISTS 'streamers' (
-	name VARCHAR(255) PRIMARY KEY,
-	last_stream DATE
-);
-	`);
-}
 
 export function getStreamers() {
   const query = database.prepare(`SELECT * FROM streamers;`);


### PR DESCRIPTION
close #6 

Added a tiny system to handle migrations. 

For every changes you want to do in your database, you have to create a `XXXX-description.sql` file with `XXXX` being a number that handle the order of executions.
Then, you run `npm run migrate` and your database should be updated with last db changes.